### PR TITLE
chore: Update devcontainer configuration

### DIFF
--- a/.devcontainer/cli/.devcontainer/devcontainer.json
+++ b/.devcontainer/cli/.devcontainer/devcontainer.json
@@ -1,14 +1,15 @@
 {
   "name": "rust",
-  "image": "ghcr.io/hankei6km/h6-dev-containers:cli_rust",
-  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
-
+  "image": "ghcr.io/hankei6km/test-dev-containers-images:rust-cli_latest",
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined"
+  ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "uname -a",
-
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-  "remoteUser": "vscode"
+  "remoteUser": "devcontainer"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,40 +1,26 @@
 {
   "name": "rust",
-  "image": "ghcr.io/hankei6km/h6-dev-containers:rust",
-  "runArgs": ["--init", "--privileged"],
-  "overrideCommand": false,
-
+  "image": "ghcr.io/hankei6km/test-dev-containers-images:rust_latest",
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
-
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": "uname -a",
-
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-  "remoteUser": "vscode",
-  "remoteEnv": {
-    "GDFUSE_SA": "${localEnv:GDFUSE_SA}",
-    "BOOTSTRAP_CODE": "${localEnv:BOOTSTRAP_CODE}"
+  "remoteUser": "devcontainer",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false
+    },
+    "ghcr.io/devcontainers-extra/features/devcontainers-cli:1": {}
   },
-  "postStartCommand": [
-    "/home/vscode/.local/bin/mount-gd.sh",
-    "/home/vscode/gdrive"
-  ],
   "customizations": {
     "vscode": {
       "settings": {
         "lldb.executable": "/usr/bin/lldb",
         "files.watcherExclude": {
           "**/target/**": true
-        },
-        "rust-analyzer.checkOnSave.command": "clippy"
-      },
-      "extensions": [
-        "rust-lang.rust-analyzer",
-        "vadimcn.vscode-lldb",
-        "tamasfe.even-better-toml",
-        "esbenp.prettier-vscode"
-      ]
+        }
+        // "rust-analyzer.checkOnSave.command": "clippy"
+      }
     }
-  }
-}
+  }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Build inside Dev Container
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/hankei6km/h6-dev-containers
-          imageTag: 2022-12-01-main-cli_rust
+          imageName: ghcr.io/hankei6km/test-dev-containers-images
+          imageTag: rust-cli__2025-05-19
           push: never
           subFolder: .devcontainer/cli
           runCmd: |
@@ -104,8 +104,8 @@ jobs:
       - name: Publish
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/hankei6km/h6-dev-containers
-          imageTag: 2022-12-01-main-cli_rust
+          imageName: ghcr.io/hankei6km/test-dev-containers-images
+          imageTag: rust-cli__2025-05-19
           push: never
           subFolder: .devcontainer/cli
           runCmd: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Run tests inside Dev Container
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/hankei6km/h6-dev-containers
-          imageTag: 2022-12-01-main-cli_rust
+          imageName: ghcr.io/hankei6km/test-dev-containers-images
+          imageTag: rust-cli__2025-05-19
           push: never
           subFolder: .devcontainer/cli
           runCmd: |


### PR DESCRIPTION
dependabot の更新でエラーになるが、利用しているプレビルドイメージは構造が古いので
更新継続は難しい。

新しく試している Dev Containers 用イメージを利用。
